### PR TITLE
"DataBase" -> "Database"

### DIFF
--- a/Database-and-DataSource.md
+++ b/Database-and-DataSource.md
@@ -1,4 +1,4 @@
-### Working with DataBase and DataSource
+### Working with Database and DataSource
 Every database access using Exposed is starting by obtaining a connection and creating a transaction.  
 First of all, you have to tell Exposed how to connect to a database by using `Database.connect` function. 
 It won't create a real database connection but only provide a descriptor for future usage.

--- a/Getting-Started.md
+++ b/Getting-Started.md
@@ -87,7 +87,7 @@ It is also possible to provide `javax.sql.DataSource` for advanced behaviors suc
 Database.connect(dataSource)
 ```
 
-More details on [[DataBase and DataSource|DataBase-and-DataSource]]
+More details on [[Database and DataSource|Database-and-DataSource]]
 
 After obtaining a connection all SQL statements should be placed inside a transaction:
 

--- a/Home.md
+++ b/Home.md
@@ -7,7 +7,7 @@ This wiki contains the following pages:
 
   * [[Introduction|Home]] - This page
   * [[Getting Started|Getting-Started]]
-  * [[DataBase and DataSource|DataBase-and-DataSource]]
+  * [[Database and DataSource|Database-and-DataSource]]
   * [[Transactions|Transactions]]
   * [[DSL API|DSL]]
   * [[DAO API|DAO]]

--- a/LibDocumentation.md
+++ b/LibDocumentation.md
@@ -132,7 +132,7 @@ exposedVersion=0.40.1
 ```
 
 ### JDBC driver and logging
-You also need a JDBC driver for the database system you are using (see [[DataBase and DataSource|DataBase-and-DataSource]]) and a logger for `addLogger(StdOutSqlLogger)`. Example (Gradle syntax):
+You also need a JDBC driver for the database system you are using (see [[Database and DataSource|Database-and-DataSource]]) and a logger for `addLogger(StdOutSqlLogger)`. Example (Gradle syntax):
 ```kotlin
 dependencies {
     // for H2

--- a/_Sidebar.md.md
+++ b/_Sidebar.md.md
@@ -1,6 +1,6 @@
   * [[Introduction|Home]]
   * [[Getting Started|Getting-Started]]
-  * [[DataBase and DataSource|DataBase-and-DataSource]]
+  * [[Database and DataSource|Database-and-DataSource]]
   * [[Transactions|Transactions]]
   * [[DSL API|DSL]]
   * [[DAO API|DAO]]


### PR DESCRIPTION
"DataBase" is not standard and is only used in one place in Exposed, not referred to in this wiki:

https://github.com/JetBrains/Exposed/blob/6b367afc6a71d973c1cecebb0b653c60461b236d/exposed-core/src/main/kotlin/org/jetbrains/exposed/sql/SchemaUtils.kt#L479-L479

Update all occurences to "Database".