### PR TITLE
Add description on how to setup DB table to use a different name

### DIFF
--- a/DAO.md
+++ b/DAO.md
@@ -29,6 +29,20 @@ object StarWarsFilms : Table() {
   override val primaryKey = PrimaryKey(id, name = "PK_StarWarsFilms_Id") // PK_StarWarsFilms_Id is optional here
 }
 ```
+By default, the lower case of the DB table representation will be used as the table name unless another name is explicitly
+specified. In this case, Exposed will assume the `StarWarsFilms` stores records in the `starwarsfilms` table.
+
+If your DB table representation name does not fit this convention, you may manually specify the
+table name by calling the `Table` constructor with the correct name as argument:
+```kotlin
+object StarWarsFilms : Table("star_wars_films") {
+  val id: Column<Int> = integer("id").autoIncrement()
+  val sequelId: Column<Int> = integer("sequel_id").uniqueIndex()
+  val name: Column<String> = varchar("name", 50)
+  val director: Column<String> = varchar("director", 50)
+  override val primaryKey = PrimaryKey(id, name = "PK_StarWarsFilms_Id") // PK_StarWarsFilms_Id is optional here
+}
+```
 Tables that contain an `Int` id with the name `id` can be declared like this:
 ```kotlin
 object StarWarsFilms : IntIdTable() {


### PR DESCRIPTION
Currently the Wiki introduces only a single use behaviour of the `Table` constructor, calling it without an argument.

This PR adds a description of what this default behaviour is and how it can be altered to match different database table naming conventions.